### PR TITLE
Fix the license value on main.yml

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,5 +13,5 @@ galaxy_info:
     - name: EL
       versions:
         - 7
-  license: GPL-3.0-or-later
+  license: AGPL-3.0-or-later
   min_ansible_version: '2.1'


### PR DESCRIPTION
As the license has been specified to AGPL with 78d3024c5ed5e96a3f25cd6a3f11bab51fdbd499, I think the license has been incorrectly specified on this file.